### PR TITLE
WP-2105-replace-union

### DIFF
--- a/wazo_dird_client/types.py
+++ b/wazo_dird_client/types.py
@@ -1,7 +1,8 @@
 # Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
 from __future__ import annotations
 
-from typing import TypeAlias, Union
+from typing import TypeAlias
 
-JSON: TypeAlias = Union[str, int, float, bool, None, list['JSON'], dict[str, 'JSON']]
+JSON: TypeAlias = str | int | float | bool | None | list['JSON'] | dict[str, 'JSON']


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use PEP 604 union syntax for `JSON` TypeAlias and drop `Union` import in `wazo_dird_client/types.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d1a1a33baa3f38f0a0bb7f2a7d942b7643529ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->